### PR TITLE
Fix README bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ Upon successful boot, as part of entering the multi-user.target stage, anything 
 1. Make any necessary changes to the content of scheduled-reboot
 2. Update the `Version:` setting in the DEBIAN/control file of the package folder hierarchy
 3. Git mv the package folder hierarchy from the old version number to the new version number
-4. Run `dpkg --build ./scheduled-reboot-n.nn
+4. Run `dpkg --build ./scheduled-reboot-n.nn` to create the Debian package


### PR DESCRIPTION
## Summary
- close backquote in README
- finish the last instruction line for building the apt package

## Testing
- `bash -n scheduled-reboot-0.20/*` *(fails: no network access)*